### PR TITLE
fix: update stale playwright.dev sidebar locator in sample tests

### DIFF
--- a/src/test/java/SampleTest1.java
+++ b/src/test/java/SampleTest1.java
@@ -39,7 +39,7 @@ public class SampleTest1 extends BaseTest {
       page.locator("text=Visual comparisons").first().click();
       page.locator("text=Fixtures").first().click();
       page.locator("text=TypeScript").first().click();
-      page.locator("text=Components (experimental)").first().click();
+      page.locator("text=Component testing").first().click();
       page.locator("text=Library").first().click();
       page.locator("text=Auto-waiting").first().click();
       page.locator("text=Authentication").first().click();

--- a/src/test/java/SampleTest2.java
+++ b/src/test/java/SampleTest2.java
@@ -39,7 +39,7 @@ public class SampleTest2 extends BaseTest {
       page.locator("text=Visual comparisons").first().click();
       page.locator("text=Fixtures").first().click();
       page.locator("text=TypeScript").first().click();
-      page.locator("text=Components (experimental)").first().click();
+      page.locator("text=Component testing").first().click();
       page.locator("text=Library").first().click();
       page.locator("text=Auto-waiting").first().click();
       page.locator("text=Authentication").first().click();

--- a/yaml/win/junit_hyperexecute_matrix_sample.yaml
+++ b/yaml/win/junit_hyperexecute_matrix_sample.yaml
@@ -30,7 +30,7 @@ matrix:
 
 pre:
  # install playwright version to be used.
-  - npm install playwright@1.23.0 --save-exact
+  - npm install playwright@1.57.0 --save-exact
   # Download and install packages in the .m2 folder.
   # Skip execution of the tests in the pre step
   - mvn -Dmaven.repo.local=./.m2 -Dmaven.test.skip=true clean install


### PR DESCRIPTION
## Problem

`SampleTest1` and `SampleTest2` both click through the playwright.dev docs sidebar. One of the entries was renamed upstream on the docs site — *"Components (experimental)"* is now *"Component testing"* — so this line no longer matches anything and the tests fail at the test level:

```java
page.locator("text=Components (experimental)").first().click();
```

## Changes

- Update the locator to `text=Component testing` in both sample test classes.
- Bump the Windows `pre` step's npm playwright install from `1.23.0` to `1.57.0`, matching `pom.xml` and what `yaml/linux` already uses.

### Note on the npm bump

The samples connect to a **remote** browser via `wss://cdp.lambdatest.com/playwright` (`BaseTest.createConnection`), and Java Playwright ships its own driver bundle, so this npm install isn't used at runtime — the bump is purely for consistency with `pom.xml`. It was **not** exercised by the verifying run below, which still used `1.23.0`. `yaml/mac` is also still on `1.23.0`; I left it alone to keep this diff minimal, happy to align it too if you'd prefer.

## Verification

HyperExecute win matrix job, `yaml/win/junit_hyperexecute_matrix_sample.yaml`:

```
✔ [1] SampleTest1  (1m0s)      ✔ [2] SampleTest2  (56s)
Test stage: 100.00% pass       Failed Tasks: 0
```

All 10 stages green across both matrix tasks. Not re-verified on linux/mac, though the locator change is platform-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)